### PR TITLE
Cookie & Header Parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import uvicorn
 
 from typing import List
 
-from fastapi import FastAPI, Query, Path
+from fastapi import FastAPI, Query, Path, Cookie, Header
 from pydantic import BaseModel, parse_obj_as, Field
 
 app = FastAPI()
@@ -67,6 +67,21 @@ class Item(BaseModel):
 @app.post("/users/{user_id}/item")
 def create_item(item: Item):
     return item
+
+
+# ----------------------------------
+
+
+@app.get("/cookie")
+def get_cookies(ga: str = Cookie(None)):
+    return {"ga": ga}
+    
+
+@app.get("/header")
+def get_headers(x_token: str = Header(None, title="토큰")):
+    return {"X-Token": x_token}
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 1. 쿠키 매개변수  
  - fastapi 모듈의 Cookie 클래스를 import해서 사용
  - Cookie 클래스의 인스턴스로 함수의 매개변수를 기본매개변수로 할당
  - docs를 이용한 테스트 시, 버그로 인한 정상 테스트 불가
  - HTTPie를 이용한 테스트 시, 쿠키는 Cookie:\<key>=\<value>;\<key>=\<value>와 같이 작성

### 2. 헤더 매개변수
 - fastapi 모듈의 Header 클래스를 import해서 사용
 - Header 클래스의 인스턴스로 함수의 매개변수를 기본매개변수로 할당
 - 표준 헤더와 구분짓기 위해 헤더에 'X-' 접두어를 붙여서 사용자 정의 헤더임을 표
 - 파이썬에서 -을 변수명으로 허락하지 않기 떄문에, 언더스코어(_)를 대신 사용
 - 헤더에서는 FastAPI가 자동으로 하이픈(-)으로 변환해서 요청을 보내게 됨
 - Header는 다른 클래스와 다르게 convert_underscores 옵션을 갖는데 False를 줄 경우 하이픈을 언더스코어로 변환x